### PR TITLE
Fix positioning issues in tl_module palette

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
  * @license   MIT
  */
 
-foreach (['navigation', 'customnav'] as $item) {
-    $GLOBALS['TL_DCA']['tl_module']['palettes'][$item] =
-        str_replace('{nav_legend}', '{nav_legend},menuAlias', $GLOBALS['TL_DCA']['tl_module']['palettes'][$item]);
-}
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+PaletteManipulator::create()
+    ->addField('menuAlias', 'nav_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('navigation', 'tl_module')
+    ->applyToPalette('customnav', 'tl_module')
+;
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['menuAlias'] = [
     'exclude'   => true,
     'inputType' => 'text',
-    'eval'      => ['maxlength' => 255, 'tl_class' => 'w50', 'unique' => true],
+    'eval'      => ['maxlength' => 255, 'tl_class' => 'w50 clr', 'unique' => true],
     'sql'       => "varchar(255) NOT NULL default ''",
 ];


### PR DESCRIPTION
This fixes a layout glitch for the custom navigation module palette. 

The menu alias is now appended as the last element in the palette and always clears floats.