### PR TITLE
Add default link attributes

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 

--- a/src/DependencyInjection/RichardhjContaoKnpMenuExtension.php
+++ b/src/DependencyInjection/RichardhjContaoKnpMenuExtension.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 
@@ -182,6 +182,18 @@ class MenuBuilder
         // Set the rel attribute
         if (!empty($arrRel)) {
             $item->setLinkAttribute('rel', implode(' ', $arrRel));
+        }
+
+        if ($title = $page->pageTitle ?: $page->title) {
+            $item->setLinkAttribute('title', $title);
+        }
+
+        if ($page->accesskey) {
+            $item->setLinkAttribute('accesskey', $page->accesskey);
+        }
+
+        if ($page->tabindex) {
+            $item->setLinkAttribute('tabindex', $page->tabindex);
         }
 
         foreach ($extra as $k => $v) {

--- a/src/Menu/NavigationModuleProvider.php
+++ b/src/Menu/NavigationModuleProvider.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 

--- a/src/RichardhjContaoKnpMenuBundle.php
+++ b/src/RichardhjContaoKnpMenuBundle.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /*
  * This file is part of richardhj/contao-knp-menu.
  *
- * Copyright (c) 2020-2020 Richard Henkenjohann
+ * Copyright (c) 2020-2021 Richard Henkenjohann
  *
  * @package   richardhj/contao-knp-menu
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2020-2020 Richard Henkenjohann
+ * @copyright 2020-2021 Richard Henkenjohann
  * @license   MIT
  */
 


### PR DESCRIPTION
The current version already adds the `target=""` and `rel=""` attributes to the link.

This PR also adds the `title=""`, `tabindex=""` and `accesskey=""` attributes to the link attributes, that are defaulted in the `nav_default.html5`.

This PR simplifies templates, as you don't need to add these attributes to your templates.
On the other hand, this is a change in the default behavior of Contao.

@m-vo WDYT?