### PR TITLE
Fix exceptions when pageModel request attribute is of type int

### DIFF
--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -54,9 +54,15 @@ class MenuBuilder
             return $root;
         }
 
+        $pageAdapter   = $this->framework->getAdapter(PageModel::class);
+
         $groups      = [];
         $request     = $this->requestStack->getCurrentRequest();
         $requestPage = $request->attributes->get('pageModel');
+
+        if (is_int($requestPage)) {
+            $requestPage = $pageAdapter->findByPk($requestPage);
+        }
 
         /** @var FrontendUser $user */
         $user = $this->framework->createInstance(FrontendUser::class);

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -86,15 +86,17 @@ class MenuBuilder
 
             // Check whether there will be subpages
             if ($page->subpages > 0) {
-                $this->getMenu($item, (int) $page->id, $level++, $host, $options);
 
+                $level++;
                 $childRecords = Database::getInstance()->getChildRecords($page->id, 'tl_page');
-                if (!$options['showLevel']
-                    || $options['showLevel'] >= $level
-                    || (!$options['hardLimit']
-                        && ((null !== $requestPage && $requestPage->id === $page->id) || \in_array($requestPage->id, $childRecords, true)))) {
-                    $item->setDisplayChildren(false);
+
+                $item->setDisplayChildren(false);
+                if (!$options['showLevel'] || $options['showLevel'] >= $level || (
+                        !$options['hardLimit'] && ($requestPage->id == $page->id || \in_array($requestPage->id, $childRecords)))) {
+                    $item->setDisplayChildren(true);
                 }
+
+                $this->getMenu($item, (int) $page->id, $level, $host, $options);
             }
 
             switch ($page->type) {

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -60,7 +60,7 @@ class MenuBuilder
         $request     = $this->requestStack->getCurrentRequest();
         $requestPage = $request->attributes->get('pageModel');
 
-        if (is_int($requestPage)) {
+        if (is_numeric($requestPage)) {
             $requestPage = $pageAdapter->findByPk($requestPage);
         }
 

--- a/src/Menu/NavigationModuleProvider.php
+++ b/src/Menu/NavigationModuleProvider.php
@@ -42,6 +42,7 @@ class NavigationModuleProvider implements MenuProviderInterface
     {
         $request       = $this->requestStack->getCurrentRequest();
         $moduleAdapter = $this->framework->getAdapter(ModuleModel::class);
+        $pageAdapter   = $this->framework->getAdapter(PageModel::class);
 
         /** @var ModuleModel $module */
         if (null === $module = $moduleAdapter->findBy('menuAlias', $name)) {
@@ -49,6 +50,10 @@ class NavigationModuleProvider implements MenuProviderInterface
         }
 
         $currentPage = null !== $request ? $request->attributes->get('pageModel') : null;
+
+        if (is_int($currentPage)) {
+            $currentPage = $pageAdapter->findByPk($currentPage);
+        }
 
         $menu    = $this->factory->createItem('root');
         $options = array_merge($module->row(), $options);

--- a/src/Menu/NavigationModuleProvider.php
+++ b/src/Menu/NavigationModuleProvider.php
@@ -51,7 +51,7 @@ class NavigationModuleProvider implements MenuProviderInterface
 
         $currentPage = null !== $request ? $request->attributes->get('pageModel') : null;
 
-        if (is_int($currentPage)) {
+        if (is_numeric($currentPage)) {
             $currentPage = $pageAdapter->findByPk($currentPage);
         }
 


### PR DESCRIPTION
We've installed this extension and got some errors since pageModel request attribute is not checked for int value. This PR adds additional checks and loads the pageModel, if the request attribute is of type int.

Update: needed to switch from is_int to is_numeric as attribute is not always of type int.

Update 2: While further working with this bundle, we run into another issue with subpage (child page) rendering. I didn't want split this PR due the additional work, so the fix is added to this PR. The child page handling now works like in contao core and like the user would expect. It is now possible to output the menu with and get the level-deph setup in the backend: 
```
{% set menu = knp_menu_get('main_navigation') %}
{{ knp_menu_render(menu) }}
```