### PR TITLE
Fix "Unknown method findPublishedSubpagesWithoutGuestsByPid" exception

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,4 +5,10 @@ services:
       - { name: knp_menu.provider }
 
   Richardhj\ContaoKnpMenuBundle\Menu\MenuBuilder:
-    arguments: ['@Knp\Menu\FactoryInterface', '@request_stack', '@contao.framework', '@event_dispatcher']
+    arguments:
+     - '@Knp\Menu\FactoryInterface'
+     - '@request_stack'
+     - '@contao.framework'
+     - '@event_dispatcher'
+     - "@contao.routing.page_registry"
+     - "@contao.security.token_checker"


### PR DESCRIPTION
This PR fix the "Unknown method findPublishedSubpagesWithoutGuestsByPid" exception when using this bundle with contao 5. 

In MenuBuilder the `PageModel::findPublishedSubpagesWithoutGuestsByPid` method is used, which is deprecated since contao 4.9. This PR replaces the method with the code copied from `\Contao\Module::getPublishedSubpagesByPid()`, since this method is protected. 

We could also go another approach with creating a proxy class for the module class making the `\Contao\Module::getPublishedSubpagesByPid()` accessible so we do not need to copy the code, but I don't know if you like that. 