### PR TITLE
Correctly include subpages in result set

### DIFF
--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -150,16 +150,16 @@ class MenuBuilder
             $beUserLoggedIn = $this->tokenChecker->isPreviewMode();
             $unroutableTypes = $this->pageRegistry->getUnroutableTypes();
 
-            $arrPages = Database::getInstance()->prepare("SELECT p1.id, EXISTS(SELECT * FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type NOT IN ('" . implode("', '", $unroutableTypes) . "')" . (!$options['showHidden'] ? " AND p2.hide=0" : "") . (!$beUserLoggedIn ? " AND p2.published=1 AND (p2.start='' OR p2.start<=$time) AND (p2.stop='' OR p2.stop>$time)" : "") . ") AS hasSubpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type NOT IN ('" . implode("', '", $unroutableTypes) . "')" . (!$options['showHidden'] ? " AND p1.hide=0" : "") . (!$beUserLoggedIn ? " AND p1.published=1 AND (p1.start='' OR p1.start<=$time) AND (p1.stop='' OR p1.stop>$time)" : "") . " ORDER BY p1.sorting")
+            $arrPages = Database::getInstance()->prepare("SELECT p1.*, EXISTS(SELECT * FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type NOT IN ('" . implode("', '", $unroutableTypes) . "')" . (!$options['showHidden'] ? " AND p2.hide=0" : "") . (!$beUserLoggedIn ? " AND p2.published=1 AND (p2.start='' OR p2.start<=$time) AND (p2.stop='' OR p2.stop>$time)" : "") . ") AS subpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type NOT IN ('" . implode("', '", $unroutableTypes) . "')" . (!$options['showHidden'] ? " AND p1.hide=0" : "") . (!$beUserLoggedIn ? " AND p1.published=1 AND (p1.start='' OR p1.start<=$time) AND (p1.stop='' OR p1.stop>$time)" : "") . " ORDER BY p1.sorting")
                 ->execute($pid)
-                ->fetchAllAssoc();
+            ;
 
-            if (\count($arrPages) < 1)
+            if ($arrPages->numRows < 1)
             {
                 return null;
             }
 
-            return PageModel::findMultipleByIds(array_map(static function ($row) { return $row['id']; }, $arrPages));
+            return Collection::createFromDbResult($arrPages, 'tl_page');
         }
 
         $ids = StringUtil::deserialize($options['pages'], true);


### PR DESCRIPTION
Fixes the issue with subpages in menus I've discovered with `1.2.2` (see https://github.com/richardhj/contao-knp-menu/pull/11#issuecomment-1821381138)