### PR TITLE
Fix customnav incompatibility with contao 5

### DIFF
--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -164,7 +164,11 @@ class MenuBuilder
 
         $ids = StringUtil::deserialize($options['pages'], true);
 
-        return PageModel::findPublishedRegularWithoutGuestsByIds($ids, ['includeRoot' => true]);
+        if (method_exists(PageModel::class, 'findPublishedRegularByIds')) {
+            return PageModel::findPublishedRegularByIds($ids, ['includeRoot' => true]);
+        } else {
+            return PageModel::findPublishedRegularWithoutGuestsByIds($ids, ['includeRoot' => true]);
+        }
     }
 
     private function populateMenuItem(MenuItem $item, ?PageModel $requestPage, PageModel $page, $href): MenuItem


### PR DESCRIPTION
This PR fixes the "Unknown method findPublishedRegularWithoutGuestsByIds" exception when using Custom Navs in combination with contao 5. In Contao 5 the method `findPublishedRegularWithoutGuestsByIds` is removed. Since `findPublishedRegularByIds` is not available in contao 4.9, I needed to add a check to evaluate which method to use.