### PR TITLE
Fix active page evaluation

### DIFF
--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -182,7 +182,7 @@ class MenuBuilder
 
         // Active page
         if (
-            $href === $path
+            ltrim($href, '/') === ltrim($path, '/')
             && ((null !== $requestPage && $requestPage->id === $page->id) || ('forward' === $page->type && $requestPage->id === $page->jumpTo))
         ) {
             $extra['isActive'] = true;


### PR DESCRIPTION
This PR fix the evaluation for the active state for the current page.
It did not work in Contao 5.7.5, the fix should not cause any problems in other environments.
