### PR TITLE
Fix exception for pages with requireItem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "knplabs/knp-menu-bundle": "^2.2. || ^3.0",
 
     "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+    "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/routing": "^4.4 || ^5.0 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "contao/easy-coding-standard": "^4.0",

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -27,6 +27,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use Richardhj\ContaoKnpMenuBundle\Event\FrontendMenuEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class MenuBuilder
@@ -71,6 +72,7 @@ class MenuBuilder
             $groups = $user->groups;
         }
 
+        /** @var PageModel $page */
         foreach ($pages as $page) {
             $item = new MenuItem($page->title, $this->factory);
 
@@ -129,7 +131,11 @@ class MenuBuilder
                     break;
 
                 default:
-                    $href = $page->getFrontendUrl();
+                    try {
+                        $href = $page->getFrontendUrl();
+                    } catch (InvalidParameterException) {
+                        continue 2;
+                    }
                     break;
             }
 


### PR DESCRIPTION
This PR catch the routing exception when a page has set "requireItem" to true. It just continue then as done in the core. 
