### PR TITLE
Use menu name for root node

### DIFF
--- a/src/Menu/NavigationModuleProvider.php
+++ b/src/Menu/NavigationModuleProvider.php
@@ -48,7 +48,7 @@ class NavigationModuleProvider implements MenuProviderInterface
             $currentPage = $pageAdapter->findByPk($currentPage);
         }
 
-        $menu = $this->factory->createItem('root');
+        $menu = $this->factory->createItem($name);
         $options = array_merge($row, $options);
 
         // Set the trail and level


### PR DESCRIPTION
This PR change the root node name from `root` to the menu name.
This will fix #16
