### PR TITLE
  Prevent infinite recursion in custom navigation module

### DIFF
--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -86,7 +86,7 @@ class MenuBuilder
             }
 
             // Check whether there will be subpages
-            if ($page->subpages > 0) {
+            if (!($options['knp_skip_subpages'] ?? false) && $page->subpages > 0) {
                 ++$level;
                 $childRecords = Database::getInstance()->getChildRecords($page->id, 'tl_page');
 

--- a/src/Menu/NavigationModuleProvider.php
+++ b/src/Menu/NavigationModuleProvider.php
@@ -74,6 +74,10 @@ class NavigationModuleProvider implements MenuProviderInterface
             $host = $rootPage->domain;
         }
 
+        if ('customnav' === ($options['type'] ?? '') && !isset($options['knp_skip_subpages'])) {
+            $options['knp_skip_subpages'] = true;
+        }
+
         return $this->builder->getMenu($menu, (int) $trail[$level], 1, $host ?? null, $options);
     }
 


### PR DESCRIPTION
 Custom navigation modules always return their configured page selection, regardless of the requested parent page. When one of these pages has subpages, the menu builder recursively processes the same selection, potentially causing an infinite loop.

This change:
  - disables recursive subpage loading for custom navigation modules by default
  - adds the `knp_skip_subpages` option to control this behavior

I prefixed the option name to stay away from potential page files with the same name.

BTW @richardhj : this is my 4. PR without any reaction and 10 months no commits. Is this extension still active? Otherwise I would detach my fork and stop make PRs here.